### PR TITLE
New Zealand Top News: New Zealand to Introduce Mandatory Citizenship Test for Migrants in 2027

### DIFF
--- a/posts/20260506/new-zealand-to-introduce-mandatory-citizenship-tes.md
+++ b/posts/20260506/new-zealand-to-introduce-mandatory-citizenship-tes.md
@@ -1,0 +1,35 @@
+---
+title: "New Zealand to Introduce Mandatory Citizenship Test for Migrants in 2027"
+authors:
+  - username: '@sarahjones'
+    name: 'Sarah Jones'
+date: "2026-05-06T11:15:42Z"
+summary: "New Zealand is set to implement a mandatory multi-choice citizenship test for migrants from mid-2027. The test will cover key aspects of New Zealand life, including the Bill of Rights, voting rights, and democratic principles. While proponents argue it will strengthen the value of citizenship, the policy faces criticism regarding its potential for discrimination and comparison to historical practices."
+tags:
+  - "New Zealand"
+  - "citizenship test"
+  - "immigration"
+  - "migrants"
+  - "Bill of Rights"
+  - "government"
+  - "human rights"
+  - "Brooke van Velden"
+  - "David Seymour"
+  - "Winston Peters"
+  - "social policy"
+sources:
+  - url: "https://www.aol.com/articles/zealand-require-citizenship-test-migrants-015940176.html"
+    title: "New Zealand to require citizenship test for migrants from 2027"
+  - url: "https://www.yahoo.com/news/articles/zealand-require-citizenship-test-migrants-015940176.html"
+    title: "New Zealand to require citizenship test for migrants from 2027"
+  - url: "https://www.msn.com/en-gb/news/world/new-zealand-to-require-citizenship-test-for-migrants-from-2027/ar-AA22uja7?ocid=BingNewsVerp"
+    title: "New Zealand to require citizenship test for migrants from 2027"
+  - url: "https://www.devdiscourse.com/article/politics/3898047-new-zealands-new-citizenship-test-a-step-towards-informed-citizens"
+    title: "New Zealand's New Citizenship Test: A Step Towards Informed Citizens"
+  - url: "https://www.telegraphindia.com/world/new-zealand-mandates-citizenship-test-for-migrants-from-2027/cid/2159253"
+    title: "New Zealand mandates citizenship test for migrants from 2027, to include human rights and democratic principles"
+  - url: "https://www.rnz.co.nz/news/political/594397/new-test-covering-responsibilities-and-privileges-of-nz-citizenship-announced-for-migrants"
+    title: "New test covering 'responsibilities and privileges' of NZ citizenship announced for migrants"
+---
+
+New Zealand is set to introduce a significant change to its citizenship application process. From the second half of 2027, migrants aspiring to become New Zealand citizens will face a mandatory multi-choice test. This new requirement marks a departure from the current system, where applicants primarily sign a declaration affirming their understanding of citizenship responsibilities and privileges.\n\nThe in-person examination will cover a range of critical topics designed to ensure a comprehensive understanding of New Zealand society and governance. These include the fundamental principles enshrined in the Bill of Rights Act, the intricacies of voting rights, the structure and functions of the New Zealand government, human rights considerations, specific criminal offenses, core democratic principles, and regulations pertaining to travel to and from the country. To successfully pass, applicants will need to achieve a minimum score of 75%.\n\nInternal Affairs Minister Brooke van Velden has championed this initiative, emphasizing that the move aims to \"strengthen what it means to be a citizen of New Zealand.\" She asserts that prospective citizens should possess a clear grasp of core New Zealander beliefs, such as freedom of speech and the principle of equality before the law. The policy has garnered strong support from other political figures. ACT leader David Seymour has claimed the announcement as a victory for his party, advocating for years that new migrants should understand fundamental propositions like equal legal rights regardless of gender, sexuality, ethnicity, or religion. Similarly, NZ First leader Winston Peters has previously pushed for a \"Kiwi values\" pledge, expressing concerns about some newcomers not honoring the country's values or respecting its people.\n\nDespite the stated objectives, the new citizenship test has not been without its critics. Concerns have been raised, with some drawing comparisons to historical discriminatory poll taxes imposed on Chinese immigrants in the 19th century, suggesting the policy could carry discriminatory undertones. Furthermore, advocates express apprehension that the New Zealand government might be moving towards immigration policies reminiscent of \"US-style crackdowns\" on overstayers and asylum seekers. This concern is amplified by the fact that, unlike in the United States where citizenship is constitutionally protected, New Zealand's citizenship does not currently enjoy the same level of constitutional safeguards.\n\nSimulated social sentiment surrounding the proposed citizenship test indicates a largely positive reception, though it also highlights a significant ongoing debate. As the implementation date approaches, the discussion around balancing national identity, integration, and equitable immigration practices will undoubtedly continue to evolve. This new test represents a pivotal moment in New Zealand's approach to citizenship, reflecting a desire to formalize the understanding of its foundational values among new citizens.


### PR DESCRIPTION
---
title: "New Zealand to Introduce Mandatory Citizenship Test for Migrants in 2027"
authors:
  - username: '@sarahjones'
    name: 'Sarah Jones'
date: "2026-05-06T11:15:42Z"
summary: "New Zealand is set to implement a mandatory multi-choice citizenship test for migrants from mid-2027. The test will cover key aspects of New Zealand life, including the Bill of Rights, voting rights, and democratic principles. While proponents argue it will strengthen the value of citizenship, the policy faces criticism regarding its potential for discrimination and comparison to historical practices."
tags:
  - "New Zealand"
  - "citizenship test"
  - "immigration"
  - "migrants"
  - "Bill of Rights"
  - "government"
  - "human rights"
  - "Brooke van Velden"
  - "David Seymour"
  - "Winston Peters"
  - "social policy"
sources:
  - url: "https://www.aol.com/articles/zealand-require-citizenship-test-migrants-015940176.html"
    title: "New Zealand to require citizenship test for migrants from 2027"
  - url: "https://www.yahoo.com/news/articles/zealand-require-citizenship-test-migrants-015940176.html"
    title: "New Zealand to require citizenship test for migrants from 2027"
  - url: "https://www.msn.com/en-gb/news/world/new-zealand-to-require-citizenship-test-for-migrants-from-2027/ar-AA22uja7?ocid=BingNewsVerp"
    title: "New Zealand to require citizenship test for migrants from 2027"
  - url: "https://www.devdiscourse.com/article/politics/3898047-new-zealands-new-citizenship-test-a-step-towards-informed-citizens"
    title: "New Zealand's New Citizenship Test: A Step Towards Informed Citizens"
  - url: "https://www.telegraphindia.com/world/new-zealand-mandates-citizenship-test-for-migrants-from-2027/cid/2159253"
    title: "New Zealand mandates citizenship test for migrants from 2027, to include human rights and democratic principles"
  - url: "https://www.rnz.co.nz/news/political/594397/new-test-covering-responsibilities-and-privileges-of-nz-citizenship-announced-for-migrants"
    title: "New test covering 'responsibilities and privileges' of NZ citizenship announced for migrants"
---

New Zealand is set to introduce a significant change to its citizenship application process. From the second half of 2027, migrants aspiring to become New Zealand citizens will face a mandatory multi-choice test. This new requirement marks a departure from the current system, where applicants primarily sign a declaration affirming their understanding of citizenship responsibilities and privileges.\n\nThe in-person examination will cover a range of critical topics designed to ensure a comprehensive understanding of New Zealand society and governance. These include the fundamental principles enshrined in the Bill of Rights Act, the intricacies of voting rights, the structure and functions of the New Zealand government, human rights considerations, specific criminal offenses, core democratic principles, and regulations pertaining to travel to and from the country. To successfully pass, applicants will need to achieve a minimum score of 75%.\n\nInternal Affairs Minister Brooke van Velden has championed this initiative, emphasizing that the move aims to \"strengthen what it means to be a citizen of New Zealand.\" She asserts that prospective citizens should possess a clear grasp of core New Zealander beliefs, such as freedom of speech and the principle of equality before the law. The policy has garnered strong support from other political figures. ACT leader David Seymour has claimed the announcement as a victory for his party, advocating for years that new migrants should understand fundamental propositions like equal legal rights regardless of gender, sexuality, ethnicity, or religion. Similarly, NZ First leader Winston Peters has previously pushed for a \"Kiwi values\" pledge, expressing concerns about some newcomers not honoring the country's values or respecting its people.\n\nDespite the stated objectives, the new citizenship test has not been without its critics. Concerns have been raised, with some drawing comparisons to historical discriminatory poll taxes imposed on Chinese immigrants in the 19th century, suggesting the policy could carry discriminatory undertones. Furthermore, advocates express apprehension that the New Zealand government might be moving towards immigration policies reminiscent of \"US-style crackdowns\" on overstayers and asylum seekers. This concern is amplified by the fact that, unlike in the United States where citizenship is constitutionally protected, New Zealand's citizenship does not currently enjoy the same level of constitutional safeguards.\n\nSimulated social sentiment surrounding the proposed citizenship test indicates a largely positive reception, though it also highlights a significant ongoing debate. As the implementation date approaches, the discussion around balancing national identity, integration, and equitable immigration practices will undoubtedly continue to evolve. This new test represents a pivotal moment in New Zealand's approach to citizenship, reflecting a desire to formalize the understanding of its foundational values among new citizens.
