### PR TITLE
Philippines Top News: Japan's Historic Pivot: Joint Military Drills Escalate in the South China Sea

### DIFF
--- a/posts/20260506/japans-historic-pivot-joint-military-drills-escala.md
+++ b/posts/20260506/japans-historic-pivot-joint-military-drills-escala.md
@@ -1,0 +1,31 @@
+---
+title: "Japan's Historic Pivot: Joint Military Drills Escalate in the South China Sea"
+authors:
+  - username: '@miguelreyes'
+    name: 'Miguel Reyes'
+date: "2026-05-06T16:06:55Z"
+summary: "Japan is making a significant 'post-war pivot' into a combat role, joining expanded military drills with the United States and the Philippines in the South China Sea. These exercises, which also involve Australia and include the deployment of advanced US anti-ship missiles, are strengthening regional alliances but also raising concerns about escalating tensions in the geopolitically vital waterway."
+tags:
+  - "Japan"
+  - "Philippines"
+  - "US"
+  - "South China Sea"
+  - "Military Drills"
+  - "Geopolitics"
+  - "Defense"
+  - "Regional Security"
+  - "Indo-Pacific"
+sources:
+  - url: "https://www.msn.com/en-us/news/world/japan-strikes-combat-role-in-south-china-sea-in-post-war-pivot/ar-AA22tOuc"
+    title: "Japan joins South China Sea combat drills with US and Philippines in post-war pivot"
+---
+
+In a historic shift marking its 'post-war pivot' towards a more active combat role, Japan is increasingly participating in joint military exercises in the South China Sea. These large-scale drills, alongside the United States and the Philippines, signify a bolstered effort to strengthen regional alliances and enhance defense capabilities in a strategically crucial waterway.
+
+The exercises are not just expanding in scope but also in participation, with new full-time involvement from nations like Japan, and Australia also launching its largest military exercises with Philippine forces. The United States has further underscored this enhanced presence by deploying anti-ship missile launchers on Batan Island in the Philippines, conducting live-fire drills to test and demonstrate advanced defense capabilities.
+
+These joint naval drills have become an annual fixture, reflecting a sustained commitment to regional security. While the stated aim is to foster interoperability and readiness among allied forces, the increased military activity in the South China Sea – a region contested by several nations, most notably China – inevitably carries the potential to heighten existing tensions. The deployment of advanced weaponry and the participation of a broader coalition of forces send a clear signal about the resolve to maintain stability and freedom of navigation in the area.
+
+Social sentiment surrounding these drills is largely positive, with public discourse often highlighting the importance of deterrence and collective security in the face of regional challenges. However, a degree of debate persists, reflecting the complex geopolitical dynamics at play and the inherent risks associated with military escalations in contested territories.
+
+The escalating frequency and scale of these joint exercises underscore a significant reorientation of defense strategies in the Indo-Pacific, with Japan's deeper combat integration representing a pivotal development in the region's evolving security landscape.


### PR DESCRIPTION
---
title: "Japan's Historic Pivot: Joint Military Drills Escalate in the South China Sea"
authors:
  - username: '@miguelreyes'
    name: 'Miguel Reyes'
date: "2026-05-06T16:06:55Z"
summary: "Japan is making a significant 'post-war pivot' into a combat role, joining expanded military drills with the United States and the Philippines in the South China Sea. These exercises, which also involve Australia and include the deployment of advanced US anti-ship missiles, are strengthening regional alliances but also raising concerns about escalating tensions in the geopolitically vital waterway."
tags:
  - "Japan"
  - "Philippines"
  - "US"
  - "South China Sea"
  - "Military Drills"
  - "Geopolitics"
  - "Defense"
  - "Regional Security"
  - "Indo-Pacific"
sources:
  - url: "https://www.msn.com/en-us/news/world/japan-strikes-combat-role-in-south-china-sea-in-post-war-pivot/ar-AA22tOuc"
    title: "Japan joins South China Sea combat drills with US and Philippines in post-war pivot"
---

In a historic shift marking its 'post-war pivot' towards a more active combat role, Japan is increasingly participating in joint military exercises in the South China Sea. These large-scale drills, alongside the United States and the Philippines, signify a bolstered effort to strengthen regional alliances and enhance defense capabilities in a strategically crucial waterway.

The exercises are not just expanding in scope but also in participation, with new full-time involvement from nations like Japan, and Australia also launching its largest military exercises with Philippine forces. The United States has further underscored this enhanced presence by deploying anti-ship missile launchers on Batan Island in the Philippines, conducting live-fire drills to test and demonstrate advanced defense capabilities.

These joint naval drills have become an annual fixture, reflecting a sustained commitment to regional security. While the stated aim is to foster interoperability and readiness among allied forces, the increased military activity in the South China Sea – a region contested by several nations, most notably China – inevitably carries the potential to heighten existing tensions. The deployment of advanced weaponry and the participation of a broader coalition of forces send a clear signal about the resolve to maintain stability and freedom of navigation in the area.

Social sentiment surrounding these drills is largely positive, with public discourse often highlighting the importance of deterrence and collective security in the face of regional challenges. However, a degree of debate persists, reflecting the complex geopolitical dynamics at play and the inherent risks associated with military escalations in contested territories.

The escalating frequency and scale of these joint exercises underscore a significant reorientation of defense strategies in the Indo-Pacific, with Japan's deeper combat integration representing a pivotal development in the region's evolving security landscape.
