### PR TITLE
Top AI News: Amazon's AI Ambitions Take Center Stage with $15 Billion Revenue Milestone and Custom Chip Dominance

### DIFF
--- a/posts/20260506/amazons-ai-ambitions-take-center-stage-with-15-bil.md
+++ b/posts/20260506/amazons-ai-ambitions-take-center-stage-with-15-bil.md
@@ -1,0 +1,34 @@
+---
+title: "Amazon's AI Ambitions Take Center Stage with $15 Billion Revenue Milestone and Custom Chip Dominance"
+authors:
+  - username: '@alanaturner'
+    name: 'Alana Turner'
+date: "2026-05-06T17:46:36Z"
+summary: "Amazon CEO Andy Jassy reveals AWS's AI services are generating over $15 billion annually, signaling the tech giant's strong foothold and future dominance in the artificial intelligence landscape, bolstered by significant investments and a rapidly growing custom chip business."
+tags:
+  - "AI"
+  - "Amazon"
+  - "AWS"
+  - "Artificial Intelligence"
+  - "Andy Jassy"
+  - "Cloud Computing"
+  - "Custom Chips"
+  - "Nvidia"
+  - "Tech Investment"
+  - "Revenue"
+sources:
+  - url: "https://nypost.com/2026/04/09/business/amazon-generating-15b-in-ai-revenue-ceo-andy-jassy-says/"
+    title: "Amazon generating $15B in AI revenue, CEO Andy Jassy says"
+---
+
+Amazon has officially entered the spotlight as a formidable player in the artificial intelligence arena, with CEO Andy Jassy announcing that the company's AI services within its cloud-computing unit, Amazon Web Services (AWS), are now generating an annualized revenue exceeding $15 billion. This marks the first time Amazon has publicly disclosed specific figures for this rapidly expanding segment, a business backed by billions of dollars in strategic investment.
+
+Based on first-quarter performance, this impressive $15 billion figure accounts for approximately 10% of AWS's staggering $142 billion revenue run-rate. Jassy's revelation, made in his annual shareholder letter, paints a confident and ambitious picture of Amazon's AI trajectory, a sentiment that resonated positively with investors, leading to a 4.6% surge in Amazon's shares following the announcement.
+
+The disclosure comes amidst heightened investor and analyst anticipation, especially given Amazon's projected capital expenditure of around $200 billion this year, primarily earmarked for AI initiatives. Jassy addressed concerns about speculative spending, assuring stakeholders that these investments are far from a 'hunch.' He emphasized that a substantial portion of the AWS capital expenditure planned for 2026, which will be monetized in 2027-2028, already has concrete customer commitments.
+
+Industry experts view this $15 billion AI revenue run-rate as a robust validation of AWS's capability to effectively translate the burgeoning AI boom into tangible, high-growth revenue, solidifying AWS's position as a leader in AI infrastructure. This achievement also places Amazon squarely in competition with rivals like Microsoft, which reported its AI business crossing an annual revenue run-rate of $13 billion in late 2024.
+
+Beyond software services, Jassy also highlighted the explosive growth in Amazon's custom chip business. This segment, encompassing Graviton processors, Trainium AI chips, and Nitro networking cards, has achieved an annualized revenue run-rate of over $20 billion, effectively doubling from the $10 billion reported in the fourth quarter. These proprietary chips are crucial to Amazon's strategy, designed to reduce its reliance on external, often costly, AI chips from manufacturers like Nvidia. Jassy even hinted at the possibility of Amazon eventually selling its custom chips to third-party customers, a strategic move that has proven successful for competitors like Google.
+
+Overall, social media sentiment surrounding Amazon's AI revenue milestones and Andy Jassy's forward-looking announcements remains largely positive, underscoring the market's excitement and confidence in Amazon's deepening commitment to the AI revolution.


### PR DESCRIPTION
---
title: "Amazon's AI Ambitions Take Center Stage with $15 Billion Revenue Milestone and Custom Chip Dominance"
authors:
  - username: '@alanaturner'
    name: 'Alana Turner'
date: "2026-05-06T17:46:36Z"
summary: "Amazon CEO Andy Jassy reveals AWS's AI services are generating over $15 billion annually, signaling the tech giant's strong foothold and future dominance in the artificial intelligence landscape, bolstered by significant investments and a rapidly growing custom chip business."
tags:
  - "AI"
  - "Amazon"
  - "AWS"
  - "Artificial Intelligence"
  - "Andy Jassy"
  - "Cloud Computing"
  - "Custom Chips"
  - "Nvidia"
  - "Tech Investment"
  - "Revenue"
sources:
  - url: "https://nypost.com/2026/04/09/business/amazon-generating-15b-in-ai-revenue-ceo-andy-jassy-says/"
    title: "Amazon generating $15B in AI revenue, CEO Andy Jassy says"
---

Amazon has officially entered the spotlight as a formidable player in the artificial intelligence arena, with CEO Andy Jassy announcing that the company's AI services within its cloud-computing unit, Amazon Web Services (AWS), are now generating an annualized revenue exceeding $15 billion. This marks the first time Amazon has publicly disclosed specific figures for this rapidly expanding segment, a business backed by billions of dollars in strategic investment.

Based on first-quarter performance, this impressive $15 billion figure accounts for approximately 10% of AWS's staggering $142 billion revenue run-rate. Jassy's revelation, made in his annual shareholder letter, paints a confident and ambitious picture of Amazon's AI trajectory, a sentiment that resonated positively with investors, leading to a 4.6% surge in Amazon's shares following the announcement.

The disclosure comes amidst heightened investor and analyst anticipation, especially given Amazon's projected capital expenditure of around $200 billion this year, primarily earmarked for AI initiatives. Jassy addressed concerns about speculative spending, assuring stakeholders that these investments are far from a 'hunch.' He emphasized that a substantial portion of the AWS capital expenditure planned for 2026, which will be monetized in 2027-2028, already has concrete customer commitments.

Industry experts view this $15 billion AI revenue run-rate as a robust validation of AWS's capability to effectively translate the burgeoning AI boom into tangible, high-growth revenue, solidifying AWS's position as a leader in AI infrastructure. This achievement also places Amazon squarely in competition with rivals like Microsoft, which reported its AI business crossing an annual revenue run-rate of $13 billion in late 2024.

Beyond software services, Jassy also highlighted the explosive growth in Amazon's custom chip business. This segment, encompassing Graviton processors, Trainium AI chips, and Nitro networking cards, has achieved an annualized revenue run-rate of over $20 billion, effectively doubling from the $10 billion reported in the fourth quarter. These proprietary chips are crucial to Amazon's strategy, designed to reduce its reliance on external, often costly, AI chips from manufacturers like Nvidia. Jassy even hinted at the possibility of Amazon eventually selling its custom chips to third-party customers, a strategic move that has proven successful for competitors like Google.

Overall, social media sentiment surrounding Amazon's AI revenue milestones and Andy Jassy's forward-looking announcements remains largely positive, underscoring the market's excitement and confidence in Amazon's deepening commitment to the AI revolution.
