### PR TITLE
Philippines Top News: Japan-Philippines Fortify Defenses: A New Era of Security Cooperation Emerges in the Indo-Pacific

### DIFF
--- a/posts/20260506/japan-philippines-fortify-defenses-a-new-era-of-se.md
+++ b/posts/20260506/japan-philippines-fortify-defenses-a-new-era-of-se.md
@@ -1,0 +1,44 @@
+---
+title: "Japan-Philippines Fortify Defenses: A New Era of Security Cooperation Emerges in the Indo-Pacific"
+authors:
+  - username: '@miguelreyes'
+    name: 'Miguel Reyes'
+date: "2026-05-06T19:33:26Z"
+summary: "Japan's Defense Minister Shinjiro Koizumi's recent visit to the Philippines marks a pivotal moment in regional security, fostering deeper military cooperation and addressing shared concerns over escalating activities in disputed waters. This visit signals a significant shift in Japan's defense posture and a fortified front against growing geopolitical complexities."
+tags:
+  - "Japan"
+  - "Philippines"
+  - "Security Ties"
+  - "Defense"
+  - "South China Sea"
+  - "Balikatan"
+  - "Shinjiro Koizumi"
+  - "Military Cooperation"
+  - "China"
+  - "Indo-Pacific"
+  - "Weapons Transfer"
+  - "Abukuma-class destroyers"
+  - "Type 88 missiles"
+  - "Reciprocal Access Agreement"
+sources:
+  - url: "https://www.khou.com/article/syndication/associatedpress/japan-defense-chief-visits-philippines-to-deepen-security-ties-and-witness-combat-exercise/616-9631feaf-1264-41ba-b3fd-54a637b2e38d"
+    title: "Japan defense chief visits Philippines to deepen security ties and witness combat exercise"
+  - url: "https://www.msn.com/en-xl/politics/government/how-the-philippines-became-japan-s-closest-security-partner-in-southeast-asia/ar-AA21yEyD?ocid=BingNewsVerp"
+    title: "How the Philippines became Japan’s closest security partner in Southeast Asia"
+  - url: "https://thediplomat.com/2026/05/japans-arms-export-shift-takes-shape-in-the-philippines/"
+    title: "Japan’s Arms Export Shift Takes Shape in the Philippines"
+  - url: "https://www.msn.com/en-ph/news/other/japanese-defense-chief-visits-ph-ahead-of-marcos-japan-trip/ar-AA22t56V?ocid=BingNewsVerp"
+    title: "Japanese defense chief visits PH ahead of Marcos’ Japan trip"
+---
+
+The Indo-Pacific region is witnessing a significant realignment of security alliances, with Japan and the Philippines at the forefront of this evolving landscape. Japanese Defense Minister Shinjiro Koizumi recently concluded a landmark visit to the Philippines, a trip aimed at substantially deepening security ties and observing critical international combat exercises. This move comes as both nations express escalating alarm over assertive actions in disputed maritime territories.
+
+During his visit, Minister Koizumi engaged in high-level discussions with Philippine Defense Secretary Gilberto Teodoro Jr. and President Ferdinand Marcos Jr. A central theme of these meetings was the shared apprehension regarding China's intensifying “coercive activities” in both the East and South China Seas. Both defense chiefs unequivocally reaffirmed their strong opposition to any unilateral attempts to alter the status quo through force or coercion.
+
+A pivotal outcome of this visit is the agreement to initiate formal discussions on a groundbreaking weapons transfer pact. This pact would enable Japan to provide used Abukuma-class destroyers to the Philippine navy. These vessels are anticipated to significantly bolster the Philippines' capabilities in maritime patrols and the detection of aerial, surface, and undersea threats. This proposed transfer underscores a profound transformation in Japan's defense policy, specifically its recent decision to lift a long-standing ban on lethal weapons exports – a major departure from its post-World War II pacifist principles.
+
+Further solidifying their commitment to regional stability, Minister Koizumi was scheduled to be a key observer at the annual Balikatan combat exercise. This large-scale joint drill brings together military forces from the United States, the Philippines, Japan, and Canada. A particularly salient aspect of the upcoming exercises will involve Japanese forces firing Type 88 missiles to successfully sink a decommissioned World War II-era Philippine navy warship. This live-fire demonstration is strategically located in waters facing the hotly contested South China Sea, sending a clear message of deterrence and combined operational readiness. The regular participation of Japanese military personnel in Balikatan is facilitated by the 2024 Reciprocal Access Agreement, further cementing this multilateral defense framework.
+
+This burgeoning security cooperation between Tokyo and Manila is a direct strategic response to the increasing assertiveness observed across the region. Unsurprisingly, these developments have drawn sharp criticism from Beijing. China's Foreign Ministry has previously lambasted Japan's evolving defense posture as a “reckless move toward a new type of militarism,” reflecting deep geopolitical tensions.
+
+Despite these criticisms, simulated social media sentiment largely indicates a positive reception to the strengthened Japan-Philippines security alliance, though some public debate remains. This historic collaboration not ironically reinforces the bilateral relationship but also significantly contributes to the broader security architecture of the Indo-Pacific, demonstrating a united front in navigating complex regional challenges.


### PR DESCRIPTION
---
title: "Japan-Philippines Fortify Defenses: A New Era of Security Cooperation Emerges in the Indo-Pacific"
authors:
  - username: '@miguelreyes'
    name: 'Miguel Reyes'
date: "2026-05-06T19:33:26Z"
summary: "Japan's Defense Minister Shinjiro Koizumi's recent visit to the Philippines marks a pivotal moment in regional security, fostering deeper military cooperation and addressing shared concerns over escalating activities in disputed waters. This visit signals a significant shift in Japan's defense posture and a fortified front against growing geopolitical complexities."
tags:
  - "Japan"
  - "Philippines"
  - "Security Ties"
  - "Defense"
  - "South China Sea"
  - "Balikatan"
  - "Shinjiro Koizumi"
  - "Military Cooperation"
  - "China"
  - "Indo-Pacific"
  - "Weapons Transfer"
  - "Abukuma-class destroyers"
  - "Type 88 missiles"
  - "Reciprocal Access Agreement"
sources:
  - url: "https://www.khou.com/article/syndication/associatedpress/japan-defense-chief-visits-philippines-to-deepen-security-ties-and-witness-combat-exercise/616-9631feaf-1264-41ba-b3fd-54a637b2e38d"
    title: "Japan defense chief visits Philippines to deepen security ties and witness combat exercise"
  - url: "https://www.msn.com/en-xl/politics/government/how-the-philippines-became-japan-s-closest-security-partner-in-southeast-asia/ar-AA21yEyD?ocid=BingNewsVerp"
    title: "How the Philippines became Japan’s closest security partner in Southeast Asia"
  - url: "https://thediplomat.com/2026/05/japans-arms-export-shift-takes-shape-in-the-philippines/"
    title: "Japan’s Arms Export Shift Takes Shape in the Philippines"
  - url: "https://www.msn.com/en-ph/news/other/japanese-defense-chief-visits-ph-ahead-of-marcos-japan-trip/ar-AA22t56V?ocid=BingNewsVerp"
    title: "Japanese defense chief visits PH ahead of Marcos’ Japan trip"
---

The Indo-Pacific region is witnessing a significant realignment of security alliances, with Japan and the Philippines at the forefront of this evolving landscape. Japanese Defense Minister Shinjiro Koizumi recently concluded a landmark visit to the Philippines, a trip aimed at substantially deepening security ties and observing critical international combat exercises. This move comes as both nations express escalating alarm over assertive actions in disputed maritime territories.

During his visit, Minister Koizumi engaged in high-level discussions with Philippine Defense Secretary Gilberto Teodoro Jr. and President Ferdinand Marcos Jr. A central theme of these meetings was the shared apprehension regarding China's intensifying “coercive activities” in both the East and South China Seas. Both defense chiefs unequivocally reaffirmed their strong opposition to any unilateral attempts to alter the status quo through force or coercion.

A pivotal outcome of this visit is the agreement to initiate formal discussions on a groundbreaking weapons transfer pact. This pact would enable Japan to provide used Abukuma-class destroyers to the Philippine navy. These vessels are anticipated to significantly bolster the Philippines' capabilities in maritime patrols and the detection of aerial, surface, and undersea threats. This proposed transfer underscores a profound transformation in Japan's defense policy, specifically its recent decision to lift a long-standing ban on lethal weapons exports – a major departure from its post-World War II pacifist principles.

Further solidifying their commitment to regional stability, Minister Koizumi was scheduled to be a key observer at the annual Balikatan combat exercise. This large-scale joint drill brings together military forces from the United States, the Philippines, Japan, and Canada. A particularly salient aspect of the upcoming exercises will involve Japanese forces firing Type 88 missiles to successfully sink a decommissioned World War II-era Philippine navy warship. This live-fire demonstration is strategically located in waters facing the hotly contested South China Sea, sending a clear message of deterrence and combined operational readiness. The regular participation of Japanese military personnel in Balikatan is facilitated by the 2024 Reciprocal Access Agreement, further cementing this multilateral defense framework.

This burgeoning security cooperation between Tokyo and Manila is a direct strategic response to the increasing assertiveness observed across the region. Unsurprisingly, these developments have drawn sharp criticism from Beijing. China's Foreign Ministry has previously lambasted Japan's evolving defense posture as a “reckless move toward a new type of militarism,” reflecting deep geopolitical tensions.

Despite these criticisms, simulated social media sentiment largely indicates a positive reception to the strengthened Japan-Philippines security alliance, though some public debate remains. This historic collaboration not ironically reinforces the bilateral relationship but also significantly contributes to the broader security architecture of the Indo-Pacific, demonstrating a united front in navigating complex regional challenges.
