### PR TITLE
New Zealand Top News: New Zealand Rugby Faces Talent Drain: The All Blacks Exodus and What It Means for the Future

### DIFF
--- a/posts/20260506/new-zealand-rugby-faces-talent-drain-the-all-black.md
+++ b/posts/20260506/new-zealand-rugby-faces-talent-drain-the-all-black.md
@@ -1,0 +1,40 @@
+---
+title: "New Zealand Rugby Faces Talent Drain: The All Blacks Exodus and What It Means for the Future"
+authors:
+  - username: '@sarahjones'
+    name: 'Sarah Jones'
+date: "2026-05-06T22:04:09Z"
+summary: "A significant player exodus is rocking New Zealand Rugby, with top All Blacks and rising Super Rugby stars opting for lucrative overseas contracts. This trend, driven by massive pay inequities, poses a major challenge to the depth and future of New Zealand's national sport."
+tags:
+  - "New Zealand Rugby"
+  - "All Blacks"
+  - "Player Exodus"
+  - "Super Rugby"
+  - "Sports Finance"
+  - "Rugby Union"
+  - "Talent Drain"
+  - "New Zealand Sports"
+sources:
+  - url: "https://www.planetrugby.com/news/full-extent-of-new-zealand-exodus-8-all-blacks-super-rugbys-hottest-prospect-and-the-biggest-blow-to-dave-rennie"
+    title: "Full Extent Of New Zealand Exodus: 8 All Blacks, Super Rugby's Hottest Prospect And The Biggest Blow To Dave Rennie"
+  - url: "https://www.msn.com/en-gb/news/insight/southern-hemisphere-talent-fuels-major-rugby-transfer-wave/gm-GM79F9C223?ocid=BingNewsVerp"
+    title: "Hansen urges NZ to adapt as player exodus grows"
+  - url: "https://www.msn.com/en-us/sports/other/all-blacks-great-jones-says-rugby-union-losing 'hearts and minds' to league/ar-AA215MOO?ocid=BingNewsVerp"
+    title: "All Blacks great Jones says rugby union losing 'hearts and minds' to league"
+  - url: "https://www.msn.com/en-gb/sport/rugby/ex-highlanders-star-urges-nz-rugby-to-review-eligibility-rules-as ‘All Blacks jersey’s pull not what it was 20 years ago’/ar-AA22nn3t?ocid=BingNewsVerp"
+    title: "Ex-Highlanders star urges NZ Rugby to review eligibility rules as ‘All Blacks jersey’s pull not what it was 20 years ago’"
+---
+
+New Zealand Rugby is currently at a critical juncture, grappling with a significant exodus of its top talent. Eight All Blacks and numerous other pivotal Super Rugby players are making the move abroad, enticed by substantial contracts in England, France, and Japan. This trend, which saw 38 players depart Kiwi Super Rugby Pacific clubs in 2024, is set to continue into 2026, raising concerns about the sport's future in the nation.
+
+The primary catalyst for this player drain is clear: a stark pay inequity. While elite All Blacks can command salaries nearing NZ$1 million annually, Super Rugby players often earn significantly less, ranging from NZ$130,000 to NZ$190,000. In stark contrast, overseas clubs are readily offering contracts worth NZ$400,000 to NZ$800,000, creating an irresistible financial pull for many players.
+
+Former All Blacks coach Sir Steve Hansen has acknowledged this player drain as an unavoidable modern reality. He urges New Zealand Rugby to accept this trend and instead concentrate on bolstering domestic development pathways to ensure a continuous supply of talent. However, the current All Blacks selection policy, which bars overseas-based players, means that while established stars generally remain, promising fringe talents and emerging prospects are increasingly slipping through the cracks.
+
+The impact on New Zealand's rugby landscape is palpable. Notable departures for 2026 include Dalton Papali’i and Hoskins Sotutu, along with rising stars Devan Flanders and Fehi Fineanganofo, whose exits are particularly impactful given their potential as future Test players. Other significant talents like AJ Lam and Xavier Roe are also linked to moves abroad, further depleting local clubs.
+
+This situation has sparked a debate, with calls for New Zealand Rugby to re-evaluate its eligibility rules. Some argue that the allure of the iconic All Blacks jersey is not as potent as it was two decades ago, and the current policy inadvertently contributes to the talent drain. Compounding these challenges, New Zealand Rugby also faces competition for "hearts and minds" from rival code rugby league, particularly among Pacific Islanders, adding another layer of complexity to their talent retention efforts.
+
+Despite the underlying concerns, social sentiment regarding the exodus is reportedly mixed, with a simulated 'mostly positive' outlook, albeit with some debate. This suggests a public perhaps resigned to, or even understanding of, players seeking better financial opportunities.
+
+Ultimately, New Zealand Rugby faces a significant test. Adapting to the realities of professional rugby's global market, reviewing existing policies, and redoubling efforts in player development will be crucial to navigating this period of transition and ensuring the long-term strength of the All Blacks and the sport within the country.


### PR DESCRIPTION
---
title: "New Zealand Rugby Faces Talent Drain: The All Blacks Exodus and What It Means for the Future"
authors:
  - username: '@sarahjones'
    name: 'Sarah Jones'
date: "2026-05-06T22:04:09Z"
summary: "A significant player exodus is rocking New Zealand Rugby, with top All Blacks and rising Super Rugby stars opting for lucrative overseas contracts. This trend, driven by massive pay inequities, poses a major challenge to the depth and future of New Zealand's national sport."
tags:
  - "New Zealand Rugby"
  - "All Blacks"
  - "Player Exodus"
  - "Super Rugby"
  - "Sports Finance"
  - "Rugby Union"
  - "Talent Drain"
  - "New Zealand Sports"
sources:
  - url: "https://www.planetrugby.com/news/full-extent-of-new-zealand-exodus-8-all-blacks-super-rugbys-hottest-prospect-and-the-biggest-blow-to-dave-rennie"
    title: "Full Extent Of New Zealand Exodus: 8 All Blacks, Super Rugby's Hottest Prospect And The Biggest Blow To Dave Rennie"
  - url: "https://www.msn.com/en-gb/news/insight/southern-hemisphere-talent-fuels-major-rugby-transfer-wave/gm-GM79F9C223?ocid=BingNewsVerp"
    title: "Hansen urges NZ to adapt as player exodus grows"
  - url: "https://www.msn.com/en-us/sports/other/all-blacks-great-jones-says-rugby-union-losing 'hearts and minds' to league/ar-AA215MOO?ocid=BingNewsVerp"
    title: "All Blacks great Jones says rugby union losing 'hearts and minds' to league"
  - url: "https://www.msn.com/en-gb/sport/rugby/ex-highlanders-star-urges-nz-rugby-to-review-eligibility-rules-as ‘All Blacks jersey’s pull not what it was 20 years ago’/ar-AA22nn3t?ocid=BingNewsVerp"
    title: "Ex-Highlanders star urges NZ Rugby to review eligibility rules as ‘All Blacks jersey’s pull not what it was 20 years ago’"
---

New Zealand Rugby is currently at a critical juncture, grappling with a significant exodus of its top talent. Eight All Blacks and numerous other pivotal Super Rugby players are making the move abroad, enticed by substantial contracts in England, France, and Japan. This trend, which saw 38 players depart Kiwi Super Rugby Pacific clubs in 2024, is set to continue into 2026, raising concerns about the sport's future in the nation.

The primary catalyst for this player drain is clear: a stark pay inequity. While elite All Blacks can command salaries nearing NZ$1 million annually, Super Rugby players often earn significantly less, ranging from NZ$130,000 to NZ$190,000. In stark contrast, overseas clubs are readily offering contracts worth NZ$400,000 to NZ$800,000, creating an irresistible financial pull for many players.

Former All Blacks coach Sir Steve Hansen has acknowledged this player drain as an unavoidable modern reality. He urges New Zealand Rugby to accept this trend and instead concentrate on bolstering domestic development pathways to ensure a continuous supply of talent. However, the current All Blacks selection policy, which bars overseas-based players, means that while established stars generally remain, promising fringe talents and emerging prospects are increasingly slipping through the cracks.

The impact on New Zealand's rugby landscape is palpable. Notable departures for 2026 include Dalton Papali’i and Hoskins Sotutu, along with rising stars Devan Flanders and Fehi Fineanganofo, whose exits are particularly impactful given their potential as future Test players. Other significant talents like AJ Lam and Xavier Roe are also linked to moves abroad, further depleting local clubs.

This situation has sparked a debate, with calls for New Zealand Rugby to re-evaluate its eligibility rules. Some argue that the allure of the iconic All Blacks jersey is not as potent as it was two decades ago, and the current policy inadvertently contributes to the talent drain. Compounding these challenges, New Zealand Rugby also faces competition for "hearts and minds" from rival code rugby league, particularly among Pacific Islanders, adding another layer of complexity to their talent retention efforts.

Despite the underlying concerns, social sentiment regarding the exodus is reportedly mixed, with a simulated 'mostly positive' outlook, albeit with some debate. This suggests a public perhaps resigned to, or even understanding of, players seeking better financial opportunities.

Ultimately, New Zealand Rugby faces a significant test. Adapting to the realities of professional rugby's global market, reviewing existing policies, and redoubling efforts in player development will be crucial to navigating this period of transition and ensuring the long-term strength of the All Blacks and the sport within the country.
