### PR TITLE
Philippines Top News: A New Era of Deterrence: US Army Fires Tomahawk from Typhon System in the Philippines

### DIFF
--- a/posts/20260506/a-new-era-of-deterrence-us-army-fires-tomahawk-fro.md
+++ b/posts/20260506/a-new-era-of-deterrence-us-army-fires-tomahawk-fro.md
@@ -1,0 +1,41 @@
+---
+title: "A New Era of Deterrence: US Army Fires Tomahawk from Typhon System in the Philippines"
+authors:
+  - username: '@miguelreyes'
+    name: 'Miguel Reyes'
+date: "2026-05-06T22:48:35Z"
+summary: "The US Army has successfully conducted a historic test-firing of a Tomahawk cruise missile from its Typhon Mid-Range Capability (MRC) launcher system in the Philippines, marking a significant development in regional security and drawing strong reactions from China."
+tags:
+  - "US Army"
+  - "Philippines"
+  - "Tomahawk Missile"
+  - "Typhon System"
+  - "Balikatan Exercises"
+  - "Indo-Pacific"
+  - "Geopolitics"
+  - "China"
+  - "Defense"
+sources:
+  - url: "https://www.msn.com/en-us/news/other/us-army-fires-tomahawk-from-typhon-launcher-in-philippines/gm-GM3A7F5255?ocid=BingNewsVerp"
+    title: "US Army fires Tomahawk from Typhon launcher in Philippines"
+  - url: "https://www.scmp.com/news/asia/southeast-asia/article/3352548/us-army-fires-typhon-first-time-philippines-during-balikatan-drills"
+    title: "US Army fires Typhon for first time in Philippines during Balikatan drills"
+  - url: "https://www.union-bulletetin.com/news/national/us-army-fires-first-tomahawk-from-philippines-in-exercise/article_366276c8-7b82-5e69-9927-3127f266a6bd.html"
+    title: "US army fires first tomahawk from Philippines in exercise"
+  - url: "https://www.newsweek.com/us-fires-tomahawk-missile-amid-tensions-with-china-over-pacific-war-games-11913808"
+    title: "US Fires Tomahawk Missile Amid Tensions With China Over Pacific War Games"
+  - url: "https://www.navalnews.com/naval-news/2026/05/us-fires-tomahawk-missile-from-typhon-launcher-in-philippines-for-the-first-time/"
+    title: "US fires Tomahawk missile from Typhon launcher in Philippines for the first time"
+  - url: "https://www.stripes.com/theaters/asia_pacific/2026-05-05/typhon-missile-launch-philippines-21580633.html"
+    title: "US military fires missile from Typhon system in Philippines for first time"
+---
+
+In a landmark demonstration of military capability and enhanced strategic cooperation, the US Army has successfully executed the first-ever test-firing of a Tomahawk cruise missile from its Typhon Mid-Range Capability (MRC) launcher system in the Philippines. This pivotal event took place during the ongoing Balikatan exercises, the largest joint military drills between the Philippines and the United States, underscoring a deepening alliance in the Indo-Pacific region.
+
+The Tomahawk missile, launched shortly after midnight from Tacloban City Airport in Leyte, precisely struck its designated target at Fort Magsaysay in Nueva Ecija, approximately 600 kilometers away. The missile, deployed without an explosive payload, served to meticulously assess the system's accuracy. The versatile Typhon system, capable of launching both Tomahawk and SM-6 missiles, was strategically deployed to the Philippines in April 2024 specifically for this joint training exercise. With an impressive strike range of up to 1,000 miles and the ability to be redirected mid-flight, the Tomahawk missile represents a formidable asset in modern defense.
+
+This year's Balikatan exercises, spanning from April 20 to May 8, are notable for their expanded scope and multilateral participation. Key allies including Australia, Japan, Canada, France, New Zealand, and the United Kingdom have joined the United States and the Philippines in extensive training across air, land, sea, space, and cyber domains. The drills have focused on critical live-fire exercises, simulating amphibious assaults, integrated air and missile defense, and maritime strike operations in strategically vital areas facing the South China Sea and Taiwan.
+
+The deployment and test-firing of the Typhon system carry significant geopolitical weight, particularly eliciting strong condemnation from China. Beijing views the system as a direct threat, asserting its capability to strike targets within Chinese territory from the Philippines, and has issued warnings against escalating geopolitical confrontation and an arms race in the region. Conversely, US Army Pacific Commander General Ronald Clark has articulated the Typhon system as a "strategic deterrent capability," deployed at the explicit request of regional allies. Philippine security officials have also expressed considerable interest in potentially acquiring the Typhon missile launcher, signaling a long-term commitment to bolstering their defense capabilities.
+
+Simulated social sentiment surrounding this landmark event suggests a generally positive public reception, albeit with ongoing discussions and varied opinions reflecting the complex strategic implications for regional stability.


### PR DESCRIPTION
---
title: "A New Era of Deterrence: US Army Fires Tomahawk from Typhon System in the Philippines"
authors:
  - username: '@miguelreyes'
    name: 'Miguel Reyes'
date: "2026-05-06T22:48:35Z"
summary: "The US Army has successfully conducted a historic test-firing of a Tomahawk cruise missile from its Typhon Mid-Range Capability (MRC) launcher system in the Philippines, marking a significant development in regional security and drawing strong reactions from China."
tags:
  - "US Army"
  - "Philippines"
  - "Tomahawk Missile"
  - "Typhon System"
  - "Balikatan Exercises"
  - "Indo-Pacific"
  - "Geopolitics"
  - "China"
  - "Defense"
sources:
  - url: "https://www.msn.com/en-us/news/other/us-army-fires-tomahawk-from-typhon-launcher-in-philippines/gm-GM3A7F5255?ocid=BingNewsVerp"
    title: "US Army fires Tomahawk from Typhon launcher in Philippines"
  - url: "https://www.scmp.com/news/asia/southeast-asia/article/3352548/us-army-fires-typhon-first-time-philippines-during-balikatan-drills"
    title: "US Army fires Typhon for first time in Philippines during Balikatan drills"
  - url: "https://www.union-bulletetin.com/news/national/us-army-fires-first-tomahawk-from-philippines-in-exercise/article_366276c8-7b82-5e69-9927-3127f266a6bd.html"
    title: "US army fires first tomahawk from Philippines in exercise"
  - url: "https://www.newsweek.com/us-fires-tomahawk-missile-amid-tensions-with-china-over-pacific-war-games-11913808"
    title: "US Fires Tomahawk Missile Amid Tensions With China Over Pacific War Games"
  - url: "https://www.navalnews.com/naval-news/2026/05/us-fires-tomahawk-missile-from-typhon-launcher-in-philippines-for-the-first-time/"
    title: "US fires Tomahawk missile from Typhon launcher in Philippines for the first time"
  - url: "https://www.stripes.com/theaters/asia_pacific/2026-05-05/typhon-missile-launch-philippines-21580633.html"
    title: "US military fires missile from Typhon system in Philippines for first time"
---

In a landmark demonstration of military capability and enhanced strategic cooperation, the US Army has successfully executed the first-ever test-firing of a Tomahawk cruise missile from its Typhon Mid-Range Capability (MRC) launcher system in the Philippines. This pivotal event took place during the ongoing Balikatan exercises, the largest joint military drills between the Philippines and the United States, underscoring a deepening alliance in the Indo-Pacific region.

The Tomahawk missile, launched shortly after midnight from Tacloban City Airport in Leyte, precisely struck its designated target at Fort Magsaysay in Nueva Ecija, approximately 600 kilometers away. The missile, deployed without an explosive payload, served to meticulously assess the system's accuracy. The versatile Typhon system, capable of launching both Tomahawk and SM-6 missiles, was strategically deployed to the Philippines in April 2024 specifically for this joint training exercise. With an impressive strike range of up to 1,000 miles and the ability to be redirected mid-flight, the Tomahawk missile represents a formidable asset in modern defense.

This year's Balikatan exercises, spanning from April 20 to May 8, are notable for their expanded scope and multilateral participation. Key allies including Australia, Japan, Canada, France, New Zealand, and the United Kingdom have joined the United States and the Philippines in extensive training across air, land, sea, space, and cyber domains. The drills have focused on critical live-fire exercises, simulating amphibious assaults, integrated air and missile defense, and maritime strike operations in strategically vital areas facing the South China Sea and Taiwan.

The deployment and test-firing of the Typhon system carry significant geopolitical weight, particularly eliciting strong condemnation from China. Beijing views the system as a direct threat, asserting its capability to strike targets within Chinese territory from the Philippines, and has issued warnings against escalating geopolitical confrontation and an arms race in the region. Conversely, US Army Pacific Commander General Ronald Clark has articulated the Typhon system as a "strategic deterrent capability," deployed at the explicit request of regional allies. Philippine security officials have also expressed considerable interest in potentially acquiring the Typhon missile launcher, signaling a long-term commitment to bolstering their defense capabilities.

Simulated social sentiment surrounding this landmark event suggests a generally positive public reception, albeit with ongoing discussions and varied opinions reflecting the complex strategic implications for regional stability.
