### PR TITLE
Top News: Jeffrey Epstein's Purported Suicide Note Unsealed by Federal Judge

### DIFF
--- a/posts/20260507/jeffrey-epsteins-purported-suicide-note-unsealed-b.md
+++ b/posts/20260507/jeffrey-epsteins-purported-suicide-note-unsealed-b.md
@@ -1,0 +1,32 @@
+---
+title: "Jeffrey Epstein's Purported Suicide Note Unsealed by Federal Judge"
+authors:
+  - username: '@elenvox'
+    name: 'Elen Vox'
+date: "2026-05-07T02:32:45Z"
+summary: "A U.S. federal judge has released a purported suicide note from convicted sex offender Jeffrey Epstein, weeks before his death, shedding new light on his state of mind and his views on the investigation against him."
+tags:
+  - "Jeffrey Epstein"
+  - "suicide note"
+  - "court release"
+  - "legal news"
+  - "criminal justice"
+  - "public opinion"
+sources:
+  - url: "https://www.msn.com/en-us/news/crime/time-to-say-goodbye-us-judge-releases-apparent-epstein-suicide-note/ar-AA22yQAl?ocid=BingNewsVerp"
+    title: "'Time to say goodbye': US judge releases apparent Epstein suicide note"
+  - url: "https://www.upi.com/Top_News/US/2026/05/06/epstein-suicide-note/1821778114136/"
+    title: "Judge releases alleged Epstein suicide note"
+  - url: "https://www.wthr.com/article/news/nation-world/judge-releases-note-that-jeffrey-epstein's-cellmate-said-he-found-after-first-suicide-attempt/507-30723213-a2e8-491f-9c1d-f8b01a05ac32"
+    title: "Judge releases note that Jeffrey Epstein's cellmate said he found after first suicide attempt"
+  - url: "https://www.msn.com/en-us/news/crime/us-court-releases-purported-epstein-suicide-note/ar-AA22ym0R?ocid=BingNewsVerp"
+    title: "US court releases purported Epstein suicide note"
+  - url: "https://www.nytimes.com/2026/05/06/nyregion/epstein-suicide-note.html"
+    title: "Purported Epstein Suicide Note Is Released"
+---
+
+A U.S. federal judge has officially unsealed and released a note, purportedly written by Jeffrey Epstein, the disgraced financier and convicted sex offender. This development offers a new, albeit controversial, glimpse into Epstein’s mindset weeks before his death in federal custody.
+
+The unsigned note was reportedly discovered by Epstein's former cellmate, hidden inside a graphic novel. This discovery followed what was believed to be Epstein's initial suicide attempt, preceding his eventual death. According to news reports, the content of the note explicitly criticized the ongoing investigation against him, though further details regarding its full scope remain under scrutiny.
+
+The release of this document has generated significant public interest, with social media sentiment described as 'mostly positive, with some debate.' This indicates a mixed but generally accepting reaction to the new information, as the public continues to seek clarity surrounding the circumstances of Epstein's demise and the broader implications of his actions.


### PR DESCRIPTION
---
title: "Jeffrey Epstein's Purported Suicide Note Unsealed by Federal Judge"
authors:
  - username: '@elenvox'
    name: 'Elen Vox'
date: "2026-05-07T02:32:45Z"
summary: "A U.S. federal judge has released a purported suicide note from convicted sex offender Jeffrey Epstein, weeks before his death, shedding new light on his state of mind and his views on the investigation against him."
tags:
  - "Jeffrey Epstein"
  - "suicide note"
  - "court release"
  - "legal news"
  - "criminal justice"
  - "public opinion"
sources:
  - url: "https://www.msn.com/en-us/news/crime/time-to-say-goodbye-us-judge-releases-apparent-epstein-suicide-note/ar-AA22yQAl?ocid=BingNewsVerp"
    title: "'Time to say goodbye': US judge releases apparent Epstein suicide note"
  - url: "https://www.upi.com/Top_News/US/2026/05/06/epstein-suicide-note/1821778114136/"
    title: "Judge releases alleged Epstein suicide note"
  - url: "https://www.wthr.com/article/news/nation-world/judge-releases-note-that-jeffrey-epstein's-cellmate-said-he-found-after-first-suicide-attempt/507-30723213-a2e8-491f-9c1d-f8b01a05ac32"
    title: "Judge releases note that Jeffrey Epstein's cellmate said he found after first suicide attempt"
  - url: "https://www.msn.com/en-us/news/crime/us-court-releases-purported-epstein-suicide-note/ar-AA22ym0R?ocid=BingNewsVerp"
    title: "US court releases purported Epstein suicide note"
  - url: "https://www.nytimes.com/2026/05/06/nyregion/epstein-suicide-note.html"
    title: "Purported Epstein Suicide Note Is Released"
---

A U.S. federal judge has officially unsealed and released a note, purportedly written by Jeffrey Epstein, the disgraced financier and convicted sex offender. This development offers a new, albeit controversial, glimpse into Epstein’s mindset weeks before his death in federal custody.

The unsigned note was reportedly discovered by Epstein's former cellmate, hidden inside a graphic novel. This discovery followed what was believed to be Epstein's initial suicide attempt, preceding his eventual death. According to news reports, the content of the note explicitly criticized the ongoing investigation against him, though further details regarding its full scope remain under scrutiny.

The release of this document has generated significant public interest, with social media sentiment described as 'mostly positive, with some debate.' This indicates a mixed but generally accepting reaction to the new information, as the public continues to seek clarity surrounding the circumstances of Epstein's demise and the broader implications of his actions.
